### PR TITLE
Add Telegram feedback bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Telegram Feedback Bot
+
+This repository contains a simple support bot for Telegram written in Python.
+
+## Features
+- Forward user messages to a private admin chat.
+- Admin replies in the chat are relayed back to the user with an individual signature.
+- Users can leave reviews using the `/review` command; reviews are stored in `reviews.txt` and sent to the admin chat.
+
+## Setup
+1. Install [python-telegram-bot](https://python-telegram-bot.org/):
+   ```bash
+   pip install python-telegram-bot
+   ```
+2. Set environment variables:
+   - `BOT_TOKEN` – token issued by [@BotFather](https://t.me/BotFather).
+   - `ADMIN_CHAT_ID` – ID of the chat where admins receive messages.
+3. Optionally register admin signatures by calling `register_admin(user_id, "Signature")` in the code.
+
+## Usage
+Run the bot:
+```bash
+python feedback_bot.py
+```
+
+The bot can be added to an admin group so that replies from administrators are forwarded back to users with their signatures.

--- a/feedback_bot.py
+++ b/feedback_bot.py
@@ -1,0 +1,88 @@
+import logging
+import os
+from typing import Dict
+
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    ContextTypes,
+    CommandHandler,
+    MessageHandler,
+    filters,
+)
+
+BOT_TOKEN = os.getenv("BOT_TOKEN")
+ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", "0"))
+# Mapping of admin user IDs to their signatures
+ADMIN_SIGNATURES: Dict[int, str] = {}
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+
+
+def register_admin(user_id: int, signature: str) -> None:
+    """Register or update an admin signature."""
+    ADMIN_SIGNATURES[user_id] = signature
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Добро пожаловать! Отправьте сообщение, чтобы связаться с поддержкой.\n"
+        "Используйте /review <текст>, чтобы оставить отзыв."
+    )
+
+
+async def forward_to_admins(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Forward user messages to the admin chat."""
+    if update.effective_chat.type != "private":
+        return
+    await update.message.forward(chat_id=ADMIN_CHAT_ID)
+
+
+async def relay_from_admins(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Relay admin replies back to the original user with signatures."""
+    if update.effective_chat.id != ADMIN_CHAT_ID:
+        return
+    if not update.message.reply_to_message or not update.message.reply_to_message.forward_from:
+        return
+    user = update.message.reply_to_message.forward_from
+    signature = ADMIN_SIGNATURES.get(update.effective_user.id, "Администратор")
+    text = f"{update.message.text}\n\n— {signature}"
+    await context.bot.send_message(chat_id=user.id, text=text)
+
+
+REVIEWS_FILE = "reviews.txt"
+
+
+async def review(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Store user reviews and notify admins."""
+    if not context.args:
+        await update.message.reply_text("Пожалуйста, отправьте отзыв после команды /review.")
+        return
+    text = " ".join(context.args)
+    with open(REVIEWS_FILE, "a", encoding="utf-8") as f:
+        f.write(f"{update.effective_user.id}\t{text}\n")
+    await update.message.reply_text("Спасибо за отзыв!")
+    await context.bot.send_message(
+        chat_id=ADMIN_CHAT_ID,
+        text=f"Новый отзыв от {update.effective_user.id}:\n{text}",
+    )
+
+
+async def main() -> None:
+    application = ApplicationBuilder().token(BOT_TOKEN).build()
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("review", review))
+    application.add_handler(MessageHandler(filters.TEXT & (~filters.COMMAND), forward_to_admins))
+    application.add_handler(MessageHandler(filters.TEXT & filters.REPLY, relay_from_admins))
+    await application.run_polling()
+
+
+if __name__ == "__main__":
+    if not BOT_TOKEN or not ADMIN_CHAT_ID:
+        raise SystemExit("Please set BOT_TOKEN and ADMIN_CHAT_ID environment variables.")
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a Python Telegram bot that forwards user messages to an admin chat and relays admin replies with signatures
- support `/review` command for collecting feedback
- document setup and usage

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile feedback_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd98f4cc04833298cd041ab4470091